### PR TITLE
Added prev and next button in guide section

### DIFF
--- a/guides/en/44_misc/0_migration-3000.md
+++ b/guides/en/44_misc/0_migration-3000.md
@@ -2,6 +2,7 @@
 title: Migrating to v3000
 description: Migrate your codebase from Kaboom v2000 to v3000.
 order: 7
+url: migration-3000
 ---
 
 # Migrating from v2000 to v3000

--- a/guides/en/44_misc/1_migration-kaplay.md
+++ b/guides/en/44_misc/1_migration-kaplay.md
@@ -2,6 +2,7 @@
 title: Migrating to KAPLAY
 description: Migrate your codebase from Kaboom v3000 to KAPLAY v3001.
 order: 6
+url: migration-kaplay
 ---
 
 # Migrating from Kaboom.js to KAPLAY

--- a/guides/en/44_misc/2_publishing.md
+++ b/guides/en/44_misc/2_publishing.md
@@ -4,6 +4,7 @@ description:
     Learn how to publish your KAPLAY game in platforms like Itch.io or
     Newgrounds.com.
 order: 6
+url: publishing
 ---
 
 # Publishing a KAPLAY game

--- a/src/components/Content/NavigationButtons.astro
+++ b/src/components/Content/NavigationButtons.astro
@@ -1,0 +1,35 @@
+---
+export type NavigationTags = {
+    url: string;
+    title: string;
+};
+type Props = {
+    previous: NavigationTags | null;
+    next: NavigationTags | null;
+};
+const { previous, next } = Astro.props;
+---
+<div class="mt-8 flex justify-between">
+    <div>
+        {previous && (
+            <a
+                href={previous.url}
+                class="hover:underline px-4 py-2"
+                aria-label="Previous guide">
+                <div class="text-sm">Previous</div>
+                <div class="font-bold">{previous.title}</div>
+            </a>
+        )}
+    </div>
+    <div>
+        {next && (
+            <a
+                href={next.url}
+                class="hover:underline px-4 py-2"
+                aria-label="Next guide">
+                <div class="text-sm">Next</div>
+                <div class="font-bold">{next.title} →</div>
+            </a>
+        )}
+    </div>
+</div>

--- a/src/pages/[...path]/guides/[slug].astro
+++ b/src/pages/[...path]/guides/[slug].astro
@@ -1,9 +1,11 @@
 ---
 import Prose from "@/components/Content/Prose.astro";
+import NavigationButtons from "@/components/Content/NavigationButtons.astro";
 import SidebarPage from "@/layouts/SidebarPage.astro";
 import { DEFAULT_LANG } from "@/util/i18n";
 import { getStaticPathsByLocales } from "@/util/path";
 import { getCollection, render } from "astro:content";
+import type { RenderedContent,CollectionEntry } from "astro:content";
 
 export async function getStaticPaths() {
     const entries = await getCollection("guides");
@@ -30,8 +32,19 @@ export async function getStaticPaths() {
 
     return entriesByLocale.filter(Boolean);
 }
-
+const previousAndNextPage = async (entry: CollectionEntry<"guides">) => {
+    const entries = await getCollection("guides");
+    const sortedEntries = entries.sort((a, b) => a.id.localeCompare(b.id));
+    const currentIndex = sortedEntries.findIndex((e) => e.id === entry.id);
+    const previous = currentIndex === 0 ? null : sortedEntries[currentIndex - 1];
+    const next = currentIndex === sortedEntries.length - 1 ? null : sortedEntries[currentIndex + 1];
+    return { 
+        previous : previous ? { url: previous.data.url!, title: previous.data.title } : null, 
+        next : next ? { url: next.data.url!, title: next.data.title } : null 
+    };
+};
 const { entry, lang } = Astro.props;
+const { previous,next } = await previousAndNextPage(entry);
 const { Content, headings } = await render(entry);
 ---
 
@@ -47,5 +60,6 @@ const { Content, headings } = await render(entry);
     headings={headings}>
     <Prose>
         <Content />
+        <NavigationButtons previous={previous} next={next} />
     </Prose>
 </SidebarPage>


### PR DESCRIPTION
Add prev and next buttons in all guide pages because i wanted that when i was going through the whole documentations 

![screenshot-20241125-064131Z-selected](https://github.com/user-attachments/assets/2bf1f402-db92-4680-af10-39b3d90bee15)

Tested it with all pages and it is working fine with all guide pages
Other things added
- Added url to misc guides
- Added order to misc guides(This is optional because misc guides are kinda sorted by file name for now but it wont be guaranteed to be in order later)