### PR TITLE
fix: add scroll padding to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,3 +16,7 @@ and this project adheres to
 ### Changed
 
 - Now nav titles are UPPERCASE
+
+### Fixed
+
+- Content no longer gets cut off by the navbar when navigating within the docs

--- a/src/layouts/SidebarPage.astro
+++ b/src/layouts/SidebarPage.astro
@@ -13,7 +13,7 @@ type Props = {
 const { sidebarMode, meta, lang, headings } = Astro.props;
 ---
 
-<Page lang={lang} meta={meta}>
+<Page lang={lang} meta={meta} class="scroll-pt-24">
     <slot name="head" slot="head" />
 
     <Sidebar sidebarMode={sidebarMode} headings={headings}>


### PR DESCRIPTION
### Fixed

- Content no longer gets cut off by the navbar when navigating within the docs