### PR TITLE
Add make-llms-txt.sh script

### DIFF
--- a/clean-all.lua
+++ b/clean-all.lua
@@ -1,0 +1,76 @@
+-- clean-all.lua
+-- Safely remove unwanted attributes, flatten divs, remove images, strip raw HTML
+
+-- Helper: safely remove attributes if they exist
+function safe_remove_attrs(elem)
+  if elem.attr then
+    elem.attr = {"", {}, {}}
+  end
+  return elem
+end
+
+-- Remove attributes and empty links
+function Link(elem)
+  if elem.content and #elem.content == 0 then
+    return {} -- Delete empty links
+  end
+  return safe_remove_attrs(elem)
+end
+
+function Span(elem)
+  return safe_remove_attrs(elem)
+end
+
+function Code(elem)
+  return safe_remove_attrs(elem)
+end
+
+-- Flatten Divs: keep only their inner content
+function Div(elem)
+  return elem.content
+end
+
+-- Remove all images
+function Image(elem)
+  return {}
+end
+
+-- Remove raw HTML blocks
+function RawBlock(elem)
+  return {}
+end
+
+-- Remove raw HTML inlines
+function RawInline(elem)
+  return {}
+end
+
+function Header(elem)
+  return safe_remove_attrs(elem)
+end
+
+-- Try to find data-language attribute for code blocks
+function CodeBlock(elem)
+  local classes = elem.attr.classes or {}
+  local attrs = elem.attr.attributes or {}
+
+  local language = nil
+  for _, pair in ipairs(attrs) do
+    local key, value = pair[1], pair[2]
+    if key == "data-language" then
+      language = value
+    end
+  end
+
+  if language then
+    -- Rebuild the attr to only have the correct language
+    elem.attr = {"", {language}, {}}
+  else
+    -- No language, just clean attributes
+    elem.attr = {"", {"js"}, {}}
+  end
+
+  return elem
+end
+
+

--- a/make-llms-txt.sh
+++ b/make-llms-txt.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -e
+
+# Wipe any previous output
+> llms.txt
+
+echo "🔨 Building llms.txt ..."
+
+# Helper function: convert a single HTML file to Markdown and clean it
+convert_html_to_md() {
+  pandoc \
+    --lua-filter=clean-all.lua \
+    --strip-comments \
+    --wrap=none \
+    -f html \
+    -t markdown-simple_tables-multiline_tables-grid_tables \
+    "$1" \
+  | sed -e "s/\\\'/'/g" -e "s/\`\`\` whitespace-pre-wrap/\`\`\`js/g"
+}
+
+# Helper function: process a whole section (optional heading + list of files)
+process_section() {
+  local heading="$1"
+  local directory="$2"
+  if [ -n "$heading" ]; then
+    echo "## $heading" >> llms.txt
+    echo "" >> llms.txt
+  fi
+  find "$directory" -name "*.html" | sort | while read file; do
+    echo "Processing $file"
+    convert_html_to_md "$file" >> llms.txt
+    echo "" >> llms.txt
+  done
+}
+
+# Process homepage separately
+echo "Processing homepage dist/index.html..."
+convert_html_to_md dist/index.html >> llms.txt
+echo "" >> llms.txt
+
+# Process sections
+process_section "Guides" "dist/guides"
+process_section "Books" "dist/books"
+process_section "Docs" "dist/docs"
+process_section "API Reference" "dist/api"
+process_section "Games" "dist/games"
+process_section "Reference" "dist/reference"
+
+echo "✅ Done! All files merged into llms.txt"
+


### PR DESCRIPTION
Add a script, `make-llms-txt.sh`, that uses pandoc and a few shell utilities (e.g. sed) to create a single, large markdown file after the manner of https://llmstxt.org.

Here is a complete llms.txt file generated for Kaplay with this script: https://gist.github.com/canadaduane/c4ae93d0e2e2425c540bcb16a2bb3de1