### PR TITLE
fix: update npm install next command

### DIFF
--- a/src/pages/next.astro
+++ b/src/pages/next.astro
@@ -44,7 +44,7 @@ import prefixVersionUrl from "@/util/prefixVersionUrl";
                             <span class="font-mono font-bold text-xs leading-none text-base-content/50">or</span>
 
                             <div class="inline-flex">
-                                <Code lang="sh" code="npm i kaplayjs@next" wrap={true} class="text-xs [--rounded-box:0.75rem]" />
+                                <Code lang="sh" code="npm i kaplay@next" wrap={true} class="text-xs [--rounded-box:0.75rem]" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
The install command for `kaplayjs@next` leads to an npm 404 error:

<img width="459" height="160" alt="Screenshot 2025-11-12 at 11 19 18 PM" src="https://github.com/user-attachments/assets/d9e02452-e628-4ab9-a216-c17f719e20e5" />

```sh
npm i kaplayjs@next
```

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/kaplayjs - Not found
npm error 404
npm error 404  'kaplayjs@next' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
```

The fix was to correct the package name:

```diff
-npm i kaplayjs@next
+npm i kaplay@next
```