### PR TITLE
docs: expand inspect mode explanation

### DIFF
--- a/guides/en/concepts/debug_mode.md
+++ b/guides/en/concepts/debug_mode.md
@@ -11,7 +11,7 @@ Now, we will see how to use it.
 
 ## Inspect Mode
 
-You can enable inspect mode by pressing <kbd class="kbd kbd-sm">F1</kbd> key. This will open the debug
+You can enable inspect mode by pressing <kbd class="kbd kbd-sm">F1</kbd> key or by setting `debug.inspect = true` in your scene. This will open the debug
 panel.
 
 ![](./assets/inspect2.png)


### PR DESCRIPTION
I didn't know it was possible to set it via code and I was constantly hitting F1 to inspect the elements. I think it's a useful tip to have, especially for folks that are going back and forth in the development.