### PR TITLE
feat: redirect docs to preferred version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.11] - 2026-04-13
+
+### Added
+
+- Added a version compatibility notice to the guides when viewed on an
+  incompatible version - @imaginarny
+- Improved the 404 page and added a notice about possible API Reference entry
+  missing in the selected version but available in another - @imaginarny
+
+### Changed
+
+- After changing the docs version, you will be redirected to the same page in
+  that version instead of the docs index page - @imaginarny
+- The selected docs version is now remembered, and you will be redirected to it
+  when navigating or visiting `/docs/guides` or `/docs/api` directly - @imaginarny
+
 ## [1.5.10] - 2026-01-10
 
 ### Added

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -28,6 +28,7 @@ export default defineConfig({
     site: "https://kaplayjs.com",
     vite: {
         define: {
+            __KAPLAY_DEFAULT_VERSION__: JSON.stringify("3001"),
             __KAPLAY_VERSION__: JSON.stringify(kaplayPackageJson.version),
             __KAPLAY_MAJORMINOR__: JSON.stringify(
                 kaplayPackageJson.version.replace(/(\d+\.\d+).*/, "$1"),

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "kaplay-site",
     "type": "module",
-    "version": "1.5.10",
+    "version": "1.5.11",
     "scripts": {
         "install": "cd kaplay && pnpm i && cd .. && pnpm run generate:all",
         "dev": "astro dev",

--- a/src/.env.d.ts
+++ b/src/.env.d.ts
@@ -1,6 +1,7 @@
 export {};
 
 declare global {
+    const __KAPLAY_DEFAULT_VERSION__: string;
     const __KAPLAY_VERSION__: string;
     const __KAPLAY_MAJORMINOR__: string;
     const __KAPLAY_MAJOR__: string;

--- a/src/components/Content/CrewBadge.astro
+++ b/src/components/Content/CrewBadge.astro
@@ -58,7 +58,7 @@ const bgColors = {
 
 <strong
     class={cn(
-        "inline-flex shrink-0 m-0.5 ml-1 align-middle font-normal drop-shadow-2 [p_&]:ml-2 [p_&]:mr-1 [p_&]:mt-0",
+        "inline-flex shrink-0 m-0.5 ml-1 align-middle font-hand font-normal drop-shadow-2 [p_&]:ml-2 [p_&]:mr-1 [p_&]:mt-0",
         textColors?.[borderColor || textColor],
         className,
     )}
@@ -69,7 +69,7 @@ const bgColors = {
         <img src={assets[crew].sprite} class="h-5 !m-0 object-scale-down scale-125 !rounded-none" alt={crew} />
     </span>
     <span class:list={["flex items-center rounded-r-lg pl-1.5 pr-2 py-1.5", bgColors[bgColor]]}>
-        <span class:list={["self-center -mt-1 font-hand text-sm leading-none", textColors[textColor]]}>
+        <span class:list={["self-center -mt-1 text-sm leading-none", textColors[textColor]]}>
             {Astro.slots.has("default") ? <slot /> : text}
         </span>
     </span>

--- a/src/components/Content/Info.astro
+++ b/src/components/Content/Info.astro
@@ -1,16 +1,19 @@
 ---
+import type { HTMLAttributes } from "astro/types";
+
 import { assets } from "@kaplayjs/crew";
 import { marked } from "marked";
+import { cn } from "@/util/cn";
 
 type Props = {
     crew: keyof typeof assets;
     title: string;
-};
+} & HTMLAttributes<"aside">;
 
-const { crew = "burpman", title = "Level Up!" } = Astro.props;
+const { crew = "burpman", title = "Level Up!", ...props } = Astro.props;
 ---
 
-<aside class="mb-4 mt-4 rounded-l-md rounded-r-box border-l-8 border-primary bg-base-200 px-4 py-2 text-base">
+<aside class={cn("mb-4 mt-4 rounded-l-md rounded-r-box border-l-8 border-primary bg-base-200 px-4 py-2 text-base", props?.class)} {...props}>
     <div class="not-prose flex items-center gap-3 text-xl font-bold my-2.5">
         {assets[crew].kind == "Sprite" && <img src={assets[crew].outlined} class="h-8" />}
         <h3 set:html={marked.parse(title)} />

--- a/src/components/Sidebar/Sidebar.astro
+++ b/src/components/Sidebar/Sidebar.astro
@@ -39,6 +39,8 @@ const { sidebarMode, headings, pageAlign } = Astro.props;
 
         <main class="relative flex w-full flex-col md:flex-row md:pt-4 md:px-4">
             <div class={cn("w-full", { "flex flex-col items-center min-w-0 [:where(&>*)]:w-full": pageAlign == "center" })}>
+                <slot name="page-start" />
+
                 <slot name="ad" />
 
                 <slot />

--- a/src/components/Sidebar/SidebarEntries.astro
+++ b/src/components/Sidebar/SidebarEntries.astro
@@ -54,7 +54,7 @@ if (sidebarMode === "guides") {
                     <SidebarCategoryLink href="/blog" icon="paper" selected={sidebarMode === "blog"}> Blog </SidebarCategoryLink>
                 </ul>
 
-                <SidebarList sidebarMode={sidebarMode} sidebarEntries={renderList} />
+                {!!renderList.length && <SidebarList sidebarMode={sidebarMode} sidebarEntries={renderList} />}
 
                 <div
                     id="sidebar-back-to-top"

--- a/src/components/Sidebar/VersionSelector.astro
+++ b/src/components/Sidebar/VersionSelector.astro
@@ -45,6 +45,7 @@ const versions = {
     <ul
         tabindex="0"
         class="dropdown-content menu w-max min-w-full mt-1.5 p-1.5 space-y-0.5 bg-base-100 rounded-lg border border-base-content/5 shadow-2xl z-[1] focus-visible:ring-2 focus-visible:ring-base-content"
+        data-version-selector-list
     >
         {
             Object.entries(versions).map(([version, { label, url }]) => (
@@ -57,6 +58,7 @@ const versions = {
                             },
                         )}
                         href={url}
+                        data-version={version.replace("v", "")}
                     >
                         {label}
                     </a>
@@ -65,3 +67,20 @@ const versions = {
         }
     </ul>
 </div>
+
+<script>
+    import { navigate } from "astro:transitions/client";
+
+    document.addEventListener("astro:page-load", () => {
+        const anchors = document.querySelectorAll<HTMLAnchorElement>("[data-version-selector-list] [data-version]");
+        const updatedUrl = (href = location.href) => new URL(location.pathname + location.search + location.hash, href).toString();
+        anchors?.forEach((a) => {
+            a.href = updatedUrl(a.href);
+            a.addEventListener("click", (e) => {
+                e.preventDefault();
+                document.cookie = `docsPreferredVersion=${a.dataset.version}; domain=.${location.hostname.split(".").slice(-2).join(".")}; path=/`;
+                navigate(updatedUrl(a.href));
+            });
+        });
+    });
+</script>

--- a/src/components/Util/VersionNotice.astro
+++ b/src/components/Util/VersionNotice.astro
@@ -1,0 +1,30 @@
+---
+import isVersion from "@/util/isVersion";
+import prefixVersionUrl from "@/util/prefixVersionUrl";
+import CrewBadge from "@/components/Content/CrewBadge.astro";
+
+type Props = {
+    version?: string;
+};
+
+const { version } = Astro.props;
+const versionUrl = prefixVersionUrl(Astro.url.pathname, version);
+---
+
+{
+    version && !isVersion(version) && (
+        <div class="mt-4 md:mt-3.5 mb-4 mx-4 md:mx-3.5">
+            <a href={versionUrl} class="inline-block hover-hover:hover:scale-105 transition-transform origin-left">
+                <CrewBadge
+                    crew="lightning"
+                    bgColor="lightorange"
+                    borderColor="lightorange"
+                    textColor="black"
+                    class="sm:scale-110 origin-left m-0 font-sans font-bold"
+                >
+                    <span class="block translate-y-0.5">This is only available in v{version}!</span>
+                </CrewBadge>
+            </a>
+        </div>
+    )
+}

--- a/src/data/next/changes.ts
+++ b/src/data/next/changes.ts
@@ -48,7 +48,7 @@ export const changes: {
         links: [
             {
                 name: "RIP make()",
-                url: prefixVersionUrl("/docs/api/ctx/make/", "3000"),
+                url: prefixVersionUrl("/docs/api/ctx/make/", "3001"),
             },
             {
                 name: "Creating Objects",

--- a/src/layouts/SidebarPage.astro
+++ b/src/layouts/SidebarPage.astro
@@ -6,6 +6,7 @@ import Page, { type MetaTagData } from "./Page.astro";
 import SearchDialog from "@/components/Search/SearchDialog.astro";
 import "@/components/Doc/Styles/DocGeneration.css";
 import "@shikijs/twoslash/style-rich.css";
+import redirectScript from "@/util/redirectToPreferredVersion";
 
 type Props = {
     meta?: MetaTagData;
@@ -16,6 +17,13 @@ const { sidebarMode, meta, headings, noAd, pageAlign } = Astro.props;
 ---
 
 <Page meta={meta} class="scroll-pt-[5.625rem]">
+    {
+        import.meta.env.PROD && (
+            // Redirects docs to the preferred version on site navigation or exact endpoints
+            <script is:inline set:html={`(${redirectScript})()`} slot="head" />
+        )
+    }
+
     <script src="/pagefind/pagefind-ui.js" is:inline defer slot="head"></script>
     <slot name="head" slot="head" />
 

--- a/src/layouts/SidebarPage.astro
+++ b/src/layouts/SidebarPage.astro
@@ -7,13 +7,15 @@ import SearchDialog from "@/components/Search/SearchDialog.astro";
 import "@/components/Doc/Styles/DocGeneration.css";
 import "@shikijs/twoslash/style-rich.css";
 import redirectScript from "@/util/redirectToPreferredVersion";
+import VersionNotice from "@/components/Util/VersionNotice.astro";
 
 type Props = {
     meta?: MetaTagData;
     noAd?: boolean;
+    version?: string;
 } & SidebarProps;
 
-const { sidebarMode, meta, headings, noAd, pageAlign } = Astro.props;
+const { sidebarMode, meta, headings, noAd, pageAlign, version } = Astro.props;
 ---
 
 <Page meta={meta} class="scroll-pt-[5.625rem]">
@@ -28,6 +30,8 @@ const { sidebarMode, meta, headings, noAd, pageAlign } = Astro.props;
     <slot name="head" slot="head" />
 
     <Sidebar sidebarMode={sidebarMode} headings={headings} pageAlign={pageAlign}>
+        <VersionNotice slot="page-start" version={version} />
+
         <slot />
 
         {!noAd && <CarbonAd slot="ad" preferStart />}

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,16 +1,90 @@
 ---
+import Info from "@/components/Content/Info.astro";
 import Prose from "@/components/Content/Prose.astro";
 import SidebarPage from "@/layouts/SidebarPage.astro";
+import { assets } from "@/data/crew";
 ---
 
-<SidebarPage>
+<SidebarPage meta={{ title: "404 Not Found" }}>
     <Prose>
-        <h1>404</h1>
-        <p class="min-h-screen">
-            Whoops! Looks like you have found a page that doesn't exist.
-            <a href="/" data-astro-reload>
-                <span class="text-primary"> Go back to the homepage</span>
-            </a>.
+        <h1 class="flex items-center gap-4 flex-wrap"
+            >404 <img class="shrink-0 !my-0 w-10 sm:w-11 rotate-6" src={assets.ghostiny.outlined} width="40" height="40" aria-hidden="true" /> Not Found</h1
+        >
+        <p>
+            Whoops! Looks like you have found a page that doesn't exist.<br />
+            <a href="/" data-astro-reload>Go back to the homepage</a>.
         </p>
+
+        <div id="notice-404-loader" class="swap grid place-content-stretch my-6 cursor-[inherit] select-auto">
+            <div class="swap-off skeleton my-0 w-full pointer-events-none"></div>
+
+            <Info class="swap-on my-0 w-full" id="notice-404" crew="api_book" title="If you got here from the API Reference page...">
+                <div data-content class="pl-11">
+                    <p
+                        >This feature might not exist in the selected version, but it could in another.<br />
+                        Try changing the version in the sidebar select.</p
+                    >
+                </div>
+            </Info>
+        </div>
     </Prose>
 </SidebarPage>
+
+<script>
+    // When user switches version browsing API Reference docs and the feature does not exist in the selected version
+    document.addEventListener("astro:page-load", async () => {
+        const loader = document.querySelector("#notice-404-loader");
+        const loaded = () => loader?.classList.toggle("swap-active", true);
+
+        if (!document.referrer) {
+            loaded();
+            return;
+        }
+
+        const referrer = new URL(document.referrer);
+        const referrerDomain = referrer.hostname.split(".").slice(-2).join(".");
+        const referrerSubdomain = referrer.hostname.replace(referrerDomain, "").replace(/\.$/, "");
+        const version = (referrerSubdomain || __KAPLAY_DEFAULT_VERSION__).replace("v", "");
+
+        if (referrerDomain != location.hostname || location.hostname.startsWith(referrerSubdomain)) {
+            loaded();
+            return;
+        }
+
+        const url = referrer + location.pathname.substring(1);
+        const fetchApiUrl = url.replace("ctx/", "ctx.").replace(/\/$/, "") + (url.endsWith(".json") ? "" : ".json");
+
+        const res = await fetch(fetchApiUrl);
+        if (!res.ok) {
+            loaded();
+            return;
+        }
+
+        const data = (await res.json())?.[0];
+
+        if (data.name) {
+            const notice = document.querySelector("#notice-404");
+            const heading = notice?.querySelector("h3");
+            const content = notice?.querySelector("[data-content]");
+
+            if (heading)
+                heading.innerHTML = `However, <code class="font-code text-white px-2 bg-base-content/15 rounded-lg">${data.name}</code> exists in v${version}!`;
+            if (content) {
+                const backBtn = document.createElement("button");
+                backBtn.classList.add("btn", "btn-sm", "btn-neutral", "mb-4", "-ml-3");
+                backBtn.textContent = `Go back to v${version} page`;
+                backBtn.onclick = () => {
+                    const versionSwitch = document.querySelector(`[data-version-selector-list] [data-version="${version}"]`);
+                    if (versionSwitch) versionSwitch.dispatchEvent(new Event("click"));
+                    else location.href = url + "?noredirect";
+                };
+
+                content.innerHTML = data.description ? `<p><q>${data.description}</q></p>` : ``;
+
+                content.append(backBtn);
+            }
+        }
+
+        loaded();
+    });
+</script>

--- a/src/pages/docs/guides/[slug].astro
+++ b/src/pages/docs/guides/[slug].astro
@@ -50,6 +50,7 @@ const { Content, headings } = await render(entry);
     sidebarMode="guides"
     headings={headings}
     noAd={entry.data.noAds ?? false}
+    version={entry.data.version}
 >
     <Prose>
         <Content

--- a/src/util/prefixVersionUrl.ts
+++ b/src/util/prefixVersionUrl.ts
@@ -4,10 +4,19 @@ export const prefixVersionUrl: (
     url: string,
     version?: string,
 ) => string = (url, version = "4000") => {
-    const subdomain = version != "3000" ? `v${version}.` : "";
+    const isCurVersion = isVersion(version);
+    const subdomain = version != __KAPLAY_DEFAULT_VERSION__
+        ? `v${version}.`
+        : "";
 
-    return (!isVersion(version) ? `https://${subdomain}kaplayjs.com/` : "/")
-        + url.replace(/^\/|\/$/g, "") + "/";
+    const link = new URL(
+        (!isCurVersion ? `https://${subdomain}kaplayjs.com/` : "/")
+            + url.replace(/^\/|\/$/g, "") + "/",
+        isCurVersion ? import.meta.env.SITE : undefined,
+    );
+    if (!isCurVersion) link.searchParams.append("noredirect", "");
+
+    return link[isCurVersion ? "pathname" : "href"].replace(/=$|=(?=&)/g, "");
 };
 
 export default prefixVersionUrl;

--- a/src/util/prefixVersionUrl.ts
+++ b/src/util/prefixVersionUrl.ts
@@ -14,9 +14,15 @@ export const prefixVersionUrl: (
             + url.replace(/^\/|\/$/g, "") + "/",
         isCurVersion ? import.meta.env.SITE : undefined,
     );
-    if (!isCurVersion) link.searchParams.append("noredirect", "");
+    if (link.pathname.startsWith("/docs")) {
+        link.searchParams.append("noredirect", "");
+    }
 
-    return link[isCurVersion ? "pathname" : "href"].replace(/=$|=(?=&)/g, "");
+    return (
+        isCurVersion
+            ? link.pathname + link.search + link.hash
+            : link.href
+    ).replace(/=$|=(?=&)/g, "");
 };
 
 export default prefixVersionUrl;

--- a/src/util/redirectToPreferredVersion.ts
+++ b/src/util/redirectToPreferredVersion.ts
@@ -13,10 +13,10 @@ export default function redirectToPreferredVersion() {
     const refOrigin = document.referrer
         ? (new URL(document.referrer)).origin
         : "";
-    const pathname = location.pathname.replace(/\/$/, "");
+    const path = location.pathname.replace(/\/$/, "");
     if (
-        !pathname.endsWith("/guides")
-        && !pathname.endsWith("/api")
+        !path.endsWith("/guides")
+        && !path.endsWith("/api")
         && refOrigin != location.origin
     ) return;
 
@@ -27,7 +27,7 @@ export default function redirectToPreferredVersion() {
         return match ? decodeURIComponent(match[2]) : null;
     };
 
-    const version = getCookie() || __KAPLAY_DEFAULT_VERSION__;
+    const version = getCookie() || __KAPLAY_MAJOR__;
     const versionSubdomain = version != __KAPLAY_DEFAULT_VERSION__
         ? `v${version}.`
         : "";
@@ -38,7 +38,7 @@ export default function redirectToPreferredVersion() {
 
     if (subdomain == versionSubdomain) return;
 
-    const { host, search, hash } = window.location;
+    const { host, pathname, search, hash } = window.location;
     const redirectHost = host.replace(subdomain, "");
     location.replace(
         `//${versionSubdomain}${redirectHost}${pathname}${search}${hash}`,

--- a/src/util/redirectToPreferredVersion.ts
+++ b/src/util/redirectToPreferredVersion.ts
@@ -1,0 +1,46 @@
+/**
+ * Redirect docs to the preferred version on site navigation or exact endpoints
+ * To be inlined in the head
+ */
+export default function redirectToPreferredVersion() {
+    if (location.search.includes("noredirect")) {
+        const url = new URL(location.href);
+        url.searchParams.delete("noredirect");
+        window.history.replaceState({}, "", url.href);
+        return;
+    }
+
+    const refOrigin = document.referrer
+        ? (new URL(document.referrer)).origin
+        : "";
+    const pathname = location.pathname.replace(/\/$/, "");
+    if (
+        !pathname.endsWith("/guides")
+        && !pathname.endsWith("/api")
+        && refOrigin != location.origin
+    ) return;
+
+    const getCookie = (name = "docsPreferredVersion") => {
+        const match = document.cookie.match(
+            new RegExp("(^|;\\s*)" + name + "=([^;]*)"),
+        );
+        return match ? decodeURIComponent(match[2]) : null;
+    };
+
+    const version = getCookie() || __KAPLAY_DEFAULT_VERSION__;
+    const versionSubdomain = version != __KAPLAY_DEFAULT_VERSION__
+        ? `v${version}.`
+        : "";
+    const subdomain = (() => {
+        const parts = location.hostname.split(".");
+        return parts.length > 2 ? `${parts[0]}.` : "";
+    })();
+
+    if (subdomain == versionSubdomain) return;
+
+    const { host, search, hash } = window.location;
+    const redirectHost = host.replace(subdomain, "");
+    location.replace(
+        `//${versionSubdomain}${redirectHost}${pathname}${search}${hash}`,
+    );
+}


### PR DESCRIPTION
### Added

- Added a version compatibility notice to the guides when viewed on an incompatible version
  <img width="400" height="217" alt="Screenshot 2026-04-08 at 19-52-45 KAPLAY Guides Prefabs" src="https://github.com/user-attachments/assets/c5c433a0-3c5d-45d1-9b26-600d7097b666" />

- Improved the 404 page and added a notice about possible API Reference entry missing in the selected version but available in another

| After changing the version on an existing page | After visiting a missing page directly |
|--------|--------|
| <img width="1150" height="498" alt="api-existing" src="https://github.com/user-attachments/assets/36f5ca0e-26cc-4f83-9650-90ab5d50aae7" /> | <img width="1148" height="482" alt="api-maybe" src="https://github.com/user-attachments/assets/5f4eb3e7-8de6-4e1c-9e63-ddf3f407c4ae" /> | 

### Changed

- After changing the docs version, you will be redirected to the same page in that version instead of the docs index page
- The selected docs version is now remembered, and you will be redirected to it when navigating or visiting `/docs/guides` or `/docs/api` directly

---

### Implementation note
There will be **_no redirect_** if:
  - The `document.referrer` does not match the page hostname (except the `/guides` and `/api` endpoints) 
    - e.g. when someone sends you an api docs link - redirected content could end up being misleading
  - There is a `?noredirect` search param when intentionally versioning links in the content, like on the `/next` page 
    - e.g. a link to a removed feature only available in xy version - you could end up on 404